### PR TITLE
pipeline: adapt data checking based on new format

### DIFF
--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
                     echo " - "$ENV
 
                     # Check if pipeline is synced
-                    IS_SYNCED=$(cy pipeline synced --org "$ORG" --project $PROJECT --env $ENV -o json 2>/dev/null | jq -r '[.[]] | all(. == null)')
+                    IS_SYNCED=$(cy pipeline synced --org "$ORG" --project $PROJECT --env $ENV -o json 2>/dev/null | jq -r '.data.synced == "synced"')
 
                     # If not synced prepare project report content in HTML format
                     if [[ "$IS_SYNCED" == "false" ]]; then


### PR DESCRIPTION
The format of the synced endpoint changed to be more verbose and easier
to deal with. So instead of checking if there are no differences, it now
checks if the state is 'synced' or not.

Closes: https://github.com/cycloid-community-catalog/stack-pipeline-synced/issues/1